### PR TITLE
Enable local GitLab with Podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,16 @@ The application—a basic TODO list app using React (frontend) and Spring Boot (
 | Observability & incident handling | Loki, Promtail, Grafana         |
 | Secure GitOps deployment          | ArgoCD + signature verification |
 
+## Running GitLab locally with Podman
+
+To keep the CI/CD environment self-contained, you can launch GitLab Community Edition in a container using the helper script:
+
+```bash
+./scripts/start-gitlab.sh
+```
+
+Set `GITLAB_HOSTNAME`, `HTTP_PORT`, or `SSH_PORT` to customize the instance. Use your chosen URL when following the steps below.
+
 
 ---
 

--- a/scripts/start-gitlab.sh
+++ b/scripts/start-gitlab.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Simple helper to run GitLab CE using Podman
+# Customize with environment variables:
+#   GITLAB_HOME   - location for GitLab data (default: ./gitlab)
+#   GITLAB_HOSTNAME - hostname used inside the container (default: gitlab.local)
+#   HTTP_PORT     - local port for HTTP access (default: 8929)
+#   SSH_PORT      - local port for SSH access (default: 2224)
+set -e
+
+GITLAB_HOME=${GITLAB_HOME:-$PWD/gitlab}
+GITLAB_HOSTNAME=${GITLAB_HOSTNAME:-gitlab.local}
+HTTP_PORT=${HTTP_PORT:-8929}
+SSH_PORT=${SSH_PORT:-2224}
+
+mkdir -p "$GITLAB_HOME/config" "$GITLAB_HOME/logs" "$GITLAB_HOME/data"
+
+podman run --detach \
+    --hostname "$GITLAB_HOSTNAME" \
+    --publish "${HTTP_PORT}:80" \
+    --publish "${SSH_PORT}:22" \
+    --name gitlab \
+    --restart always \
+    --volume "$GITLAB_HOME/config":/etc/gitlab \
+    --volume "$GITLAB_HOME/logs":/var/log/gitlab \
+    --volume "$GITLAB_HOME/data":/var/opt/gitlab \
+    gitlab/gitlab-ce:latest
+
+echo "GitLab CE is starting on http://${GITLAB_HOSTNAME}:${HTTP_PORT}"
+


### PR DESCRIPTION
## Summary
- provide a helper script to spin up GitLab CE via Podman
- document how to run GitLab locally

## Testing
- `scripts/check-sbom-diff.sh`


------
https://chatgpt.com/codex/tasks/task_e_686b940cc6848330af83dc1808ed3488