### PR TITLE
Add Maven and npm vulnerability scan jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -110,6 +110,35 @@ scan:
   only:
     - main
 
+maven-dependency-scan:
+  stage: scan
+  image: maven:3.9-eclipse-temurin-17
+  script:
+    - mvn -f todo-api/pom.xml -B org.owasp:dependency-check-maven:check -Dformat=JSON -DoutputDirectory=odc-maven
+  artifacts:
+    paths:
+      - odc-maven
+  dependencies:
+    - build
+  only:
+    - main
+
+npm-dependency-scan:
+  stage: scan
+  image: node:18-alpine
+  script:
+    - cd todo-client
+    - npm install --legacy-peer-deps
+    - npm audit --audit-level=high --json > ../npm-audit.json
+    - cd ..
+  artifacts:
+    paths:
+      - npm-audit.json
+  dependencies:
+    - build
+  only:
+    - main
+
 deploy:
   stage: deploy
   script:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The application—a basic TODO list app using React (frontend) and Spring Boot (
 ### Vulnerability Scanning
 
 * All application and base image dependencies are scanned for CVEs using **Grype** and **OWASP Dependency-Check**.
+* Maven dependencies are additionally checked with the OWASP Dependency-Check Maven plugin.
+* npm packages are audited with `npm audit` to detect published advisories.
 * CI pipelines are configured to fail if critical vulnerabilities are found.
 
 ### Container Image Signing and Verification


### PR DESCRIPTION
## Summary
- extend pipeline with `maven-dependency-scan` and `npm-dependency-scan` jobs
- document the new scanning steps in the README

## Testing
- `./mvnw -q test` *(fails: could not resolve dependencies)*
- `npm install --package-lock-only` *(fails: git connection error)*

------
https://chatgpt.com/codex/tasks/task_e_686b98b9fcb083309ed617c6a63ef6f1