### PR TITLE
Add manual malware injection docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,8 +260,9 @@ Integrate with Promtail/Loki or Slack for centralized alerting.
 ## Supply Chain Attack Simulation (Bonus Phase)
 
 1. **Introduce a suspicious dependency**
-   - The frontend `package.json` references an `evil-package` hosted at a mock URL.
-   - The backend `pom.xml` includes `com.malicious:evil-lib:1.0.0`.
+   - Follow [malicious/README.md](malicious/README.md) to build and manually install
+     the `evil-package` and `evil-lib` artifacts. The base project omits these
+     dependencies to keep the scenario realistic.
 
 2. **Generate new SBOMs and compare**
    - The CI pipeline stores SBOMs under `sboms/` and fails if they change.

--- a/malicious/README.md
+++ b/malicious/README.md
@@ -1,0 +1,43 @@
+# Supply Chain Attack Simulation
+
+This directory contains intentionally malicious packages used to demonstrate how a
+project could be infected with dependencies that appear legitimate.
+
+## evil-package (Node.js)
+
+1. Build the package:
+   ```bash
+   cd evil-package
+   npm pack
+   ```
+   This produces a `.tgz` archive under `evil-package/`.
+
+2. Infect the client application:
+   ```bash
+   cd ../../todo-client
+   npm install ../malicious/evil-package/evil-package-1.0.0.tgz
+   ```
+   The `package.json` does not include this dependency by default; installing the
+   archive adds it to `package-lock.json` for a more realistic compromise.
+
+## evil-lib (Maven)
+
+1. Build and install the library to the local Maven repository:
+   ```bash
+   cd evil-lib
+   mvn install -DskipTests
+   ```
+
+2. Add the dependency to the backend:
+   ```bash
+   cd ../../todo-api
+   mvn install:install-file \
+       -DgroupId=com.malicious \
+       -DartifactId=evil-lib \
+       -Dversion=1.0.0 \
+       -Dpackaging=jar \
+       -Dfile=../malicious/evil-lib/target/evil-lib-1.0.0.jar
+   # Then update pom.xml to reference com.malicious:evil-lib:1.0.0
+   ```
+   The manual step mimics an attacker injecting the dependency after the build
+   has started.

--- a/malicious/evil-lib/pom.xml
+++ b/malicious/evil-lib/pom.xml
@@ -1,0 +1,9 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.malicious</groupId>
+    <artifactId>evil-lib</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Evil Lib</name>
+</project>

--- a/malicious/evil-lib/src/main/java/com/malicious/EvilLib.java
+++ b/malicious/evil-lib/src/main/java/com/malicious/EvilLib.java
@@ -1,0 +1,7 @@
+package com.malicious;
+
+public class EvilLib {
+    public static void run() {
+        System.out.println("malicious code executed");
+    }
+}

--- a/todo-api/pom.xml
+++ b/todo-api/pom.xml
@@ -39,13 +39,6 @@
                         <artifactId>spring-boot-starter-web</artifactId>
                 </dependency>
 
-                <!-- Suspicious dependency for supply chain attack simulation -->
-                <dependency>
-                        <groupId>com.malicious</groupId>
-                        <artifactId>evil-lib</artifactId>
-                        <version>1.0.0</version>
-                        <scope>runtime</scope>
-                </dependency>
 
                 <dependency>
                         <groupId>org.postgresql</groupId>

--- a/todo-client/package.json
+++ b/todo-client/package.json
@@ -5,8 +5,7 @@
   "dependencies": {
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-scripts": "5.0.1",
-    "evil-package": "git+https://malicious.example.com/evil-package.git"
+    "react-scripts": "5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
## Summary
- remove direct malicious dependencies from Maven and npm projects
- add a minimal malicious Java library
- document how to build and install malicious packages
- reference new instructions from the main README

## Testing
- `npm run build` *(fails: react-scripts not found)*
- `./mvnw test` *(fails: could not resolve parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686b9ad3f0e88330b1082abe03451a42