### PR TITLE
Improve Kubernetes deployment documentation

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -8,6 +8,11 @@ It assumes you already have container images built and signed in the GitLab regi
 - Access to a Kubernetes cluster (`kubectl` configured).
 - Argo CD installed on the cluster.
 - The `cosign.pub` key applied as a ConfigMap so Argo CD can verify images.
+- The Bitnami Sealed Secrets controller installed and the `kubeseal` CLI
+  available.
+  This is required for `pg-password-sealed.yaml`.
+- Replace `REPLACE_GROUP` and `REPLACE_PROJECT` in the manifests under
+  `k8s/` with your GitLab namespace and project name before applying them.
 
 ### Installing tools on macOS
 
@@ -22,20 +27,30 @@ brew install kubectl argocd
    kubectl create namespace argocd
    kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
    ```
-2. **Deploy application manifests**
+2. **Apply the Cosign public key and sealed secret**
+   ```bash
+   kubectl apply -f k8s/cosign-public-key.yaml
+   kubectl apply -f k8s/pg-password-sealed.yaml
+   ```
+3. **Deploy core services**
    ```bash
    kubectl apply -f k8s/postgres-deployment.yaml
    kubectl apply -f k8s/todo-api-deployment.yaml
    kubectl apply -f k8s/todo-client-deployment.yaml
-   kubectl apply -f k8s/cosign-public-key.yaml
    ```
-3. **Create the Argo CD Application**
+4. **Deploy runtime monitoring and logging**
+   ```bash
+   kubectl apply -f k8s/falco-rules.yaml
+   kubectl apply -f k8s/falco-daemonset.yaml
+   kubectl apply -f k8s/loki-stack.yaml
+   ```
+5. **Create the Argo CD Application**
    ```bash
    kubectl apply -f k8s/argo-app.yaml
    ```
-4. **Sync the application**
+6. **Sync the application**
    ```bash
-   argocd app sync todo
+   argocd app sync todo-app
    ```
 
 Argo CD verifies each image with `cosign verify` before deployment.


### PR DESCRIPTION
## Summary
- document sealed secrets and placeholder replacements
- expand deployment instructions to include all manifests

## Testing
- `bash scripts/check-sbom-diff.sh`

------
https://chatgpt.com/codex/tasks/task_e_686e1d7009f88330b3d365b2d5042567