### PR TITLE
Add Helm chart and update ArgoCD deployment

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -11,8 +11,8 @@ It assumes you already have container images built and signed in the GitLab regi
 - The Bitnami Sealed Secrets controller installed and the `kubeseal` CLI
   available.
   This is required for `pg-password-sealed.yaml`.
-- Replace `REPLACE_GROUP` and `REPLACE_PROJECT` in the manifests under
-  `k8s/` with your GitLab namespace and project name before applying them.
+- Copy `.env.example` to `.env` and set `GITLAB_GROUP` and `GITLAB_PROJECT`.
+- These values are consumed by the Helm chart in `charts/todo-app`.
 
 ### Installing tools on macOS
 
@@ -27,28 +27,11 @@ brew install kubectl argocd
    kubectl create namespace argocd
    kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
    ```
-2. **Apply the Cosign public key and sealed secret**
+2. **Create the Argo CD Application**
    ```bash
-   kubectl apply -f k8s/cosign-public-key.yaml
-   kubectl apply -f k8s/pg-password-sealed.yaml
+   envsubst < k8s/argo-app.yaml | kubectl apply -f -
    ```
-3. **Deploy core services**
-   ```bash
-   kubectl apply -f k8s/postgres-deployment.yaml
-   kubectl apply -f k8s/todo-api-deployment.yaml
-   kubectl apply -f k8s/todo-client-deployment.yaml
-   ```
-4. **Deploy runtime monitoring and logging**
-   ```bash
-   kubectl apply -f k8s/falco-rules.yaml
-   kubectl apply -f k8s/falco-daemonset.yaml
-   kubectl apply -f k8s/loki-stack.yaml
-   ```
-5. **Create the Argo CD Application**
-   ```bash
-   kubectl apply -f k8s/argo-app.yaml
-   ```
-6. **Sync the application**
+3. **Sync the application**
    ```bash
    argocd app sync todo-app
    ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project assumes you’ve heard about supply chain attacks. Here, you’ll b
 * Database: PostgreSQL
 * Containerization: Podman
 * CI/CD: GitLab CI + GitLab CLI
-* GitOps Deployment: Kubernetes via ArgoCD
+* GitOps Deployment: Kubernetes via ArgoCD + Helm
 
 **Project Goals**:
 

--- a/charts/todo-app/Chart.yaml
+++ b/charts/todo-app/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: todo-app
+description: Helm chart for the TODO Hardening Initiative
+version: 0.1.0
+appVersion: "1.0"
+type: application

--- a/charts/todo-app/templates/cosign-public-key.yaml
+++ b/charts/todo-app/templates/cosign-public-key.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cosign-public-key
+  namespace: default
+data:
+  cosign.pub: |
+    -----BEGIN PUBLIC KEY-----
+    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE6haOQ3IeA5TQUV+dm8db9TVEkSPp
+    MYWA3E6I7t4bHmLxe+rdeTqL029FdLCFFJtTm1dWuUl9wZl8Itg3GzouzQ==
+    -----END PUBLIC KEY-----

--- a/charts/todo-app/templates/falco-daemonset.yaml
+++ b/charts/todo-app/templates/falco-daemonset.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: falco
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: falco
+  namespace: falco
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: falco
+rules:
+  - apiGroups: ['']
+    resources: ['pods', 'nodes']
+    verbs: ['get','watch','list']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: falco
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: falco
+subjects:
+  - kind: ServiceAccount
+    name: falco
+    namespace: falco
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: falco
+  namespace: falco
+spec:
+  selector:
+    matchLabels:
+      app: falco
+  template:
+    metadata:
+      labels:
+        app: falco
+    spec:
+      serviceAccountName: falco
+      containers:
+        - name: falco
+          image: falcosecurity/falco:0.36.1
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: dev
+              mountPath: /host/dev
+            - name: proc
+              mountPath: /host/proc
+            - name: sysfs
+              mountPath: /host/sys
+            - name: modules
+              mountPath: /host/lib/modules
+            - name: rules
+              mountPath: /etc/falco/falco-rules.d
+      volumes:
+        - name: dev
+          hostPath:
+            path: /dev
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: sysfs
+          hostPath:
+            path: /sys
+        - name: modules
+          hostPath:
+            path: /lib/modules
+        - name: rules
+          configMap:
+            name: falco-rules

--- a/charts/todo-app/templates/falco-rules.yaml
+++ b/charts/todo-app/templates/falco-rules.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: falco-rules
+  namespace: falco
+data:
+  custom_rules.yaml: |
+    - rule: Shell in Container
+      desc: Detect shell access inside a container
+      condition: container.id != host and proc.name in (bash, sh, zsh)
+      output: "Shell in container (user=%user.name container=%container.id cmd=%proc.cmdline)"
+      priority: CRITICAL
+    - rule: Outbound Connection
+      desc: Detect outbound network connection from container
+      condition: evt.type=connect and container.id!=host and fd.sip != 10.0.0.0/8
+      output: "Outbound connection detected (command=%proc.cmdline ip=%fd.sip)"
+      priority: WARNING

--- a/charts/todo-app/templates/loki-stack.yaml
+++ b/charts/todo-app/templates/loki-stack.yaml
@@ -1,0 +1,171 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+  namespace: monitoring
+data:
+  loki.yaml: |
+    auth_enabled: false
+    server:
+      http_listen_port: 3100
+    ingester:
+      wal:
+        enabled: false
+      lifecycler:
+        address: 127.0.0.1
+        ring:
+          kvstore:
+            store: inmemory
+    storage_config:
+      filesystem:
+        directory: /tmp/loki
+    schema_config:
+      configs:
+        - from: 2020-10-24
+          store: boltdb-shipper
+          object_store: filesystem
+          schema: v11
+          index:
+            prefix: index_
+            period: 24h
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loki
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: loki
+  template:
+    metadata:
+      labels:
+        app: loki
+    spec:
+      containers:
+        - name: loki
+          image: grafana/loki:2.9.0
+          args:
+            - -config.file=/etc/loki/loki.yaml
+          ports:
+            - containerPort: 3100
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki
+      volumes:
+        - name: config
+          configMap:
+            name: loki-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+  namespace: monitoring
+spec:
+  selector:
+    app: loki
+  ports:
+    - port: 3100
+      targetPort: 3100
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: promtail-config
+  namespace: monitoring
+data:
+  promtail.yaml: |
+    serverPort: 9080
+    positions:
+      filename: /tmp/positions.yaml
+    clients:
+      - url: http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push
+    scrape_configs:
+      - job_name: system
+        static_configs:
+          - targets:
+              - localhost
+            labels:
+              job: varlogs
+              __path__: /var/log/*log
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: promtail
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: promtail
+  template:
+    metadata:
+      labels:
+        app: promtail
+    spec:
+      containers:
+        - name: promtail
+          image: grafana/promtail:2.9.0
+          args:
+            - -config.file=/etc/promtail/promtail.yaml
+          volumeMounts:
+            - name: config
+              mountPath: /etc/promtail
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: promtail-config
+        - name: varlog
+          hostPath:
+            path: /var/log
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:10.1.0
+          env:
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              value: admin
+          ports:
+            - containerPort: 3000
+          volumeMounts:
+            - name: storage
+              mountPath: /var/lib/grafana
+      volumes:
+        - name: storage
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  selector:
+    app: grafana
+  ports:
+    - port: 3000
+      targetPort: 3000

--- a/charts/todo-app/templates/pg-password-sealed.yaml
+++ b/charts/todo-app/templates/pg-password-sealed.yaml
@@ -1,0 +1,8 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: pg-password
+spec:
+  encryptedData:
+    POSTGRES_PASSWORD: AgA+
+

--- a/charts/todo-app/templates/postgres-deployment.yaml
+++ b/charts/todo-app/templates/postgres-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15-alpine
+          env:
+            - name: POSTGRES_DB
+              value: todo
+            - name: POSTGRES_USER
+              value: todo
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: pg-password
+                  key: POSTGRES_PASSWORD
+          ports:
+            - containerPort: 5432
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432

--- a/charts/todo-app/templates/todo-api-deployment.yaml
+++ b/charts/todo-app/templates/todo-api-deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: todo-api
+spec:
+  selector:
+    matchLabels:
+      app: todo-api
+  template:
+    metadata:
+      labels:
+        app: todo-api
+    spec:
+      initContainers:
+        - name: verify-image
+          image: ghcr.io/sigstore/cosign:v2.2.0
+          command: ["cosign", "verify", "--key=/cosign/cosign.pub", "{{ .Values.gitlab.registry }}/{{ .Values.gitlab.group }}/{{ .Values.gitlab.project }}/todo-api:latest"]
+          volumeMounts:
+            - name: cosign-key
+              mountPath: /cosign
+      containers:
+        - name: todo-api
+          image: {{ .Values.gitlab.registry }}/{{ .Values.gitlab.group }}/{{ .Values.gitlab.project }}/todo-api:latest
+          env:
+            - name: SPRING_DATASOURCE_URL
+              value: jdbc:postgresql://postgres:5432/todo
+            - name: SPRING_DATASOURCE_USERNAME
+              value: todo
+            - name: SPRING_DATASOURCE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: pg-password
+                  key: POSTGRES_PASSWORD
+          ports:
+            - containerPort: 8080
+      volumes:
+        - name: cosign-key
+          configMap:
+            name: cosign-public-key
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: todo-api
+spec:
+  selector:
+    app: todo-api
+  ports:
+    - port: 8080

--- a/charts/todo-app/templates/todo-client-deployment.yaml
+++ b/charts/todo-app/templates/todo-client-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: todo-client
+spec:
+  selector:
+    matchLabels:
+      app: todo-client
+  template:
+    metadata:
+      labels:
+        app: todo-client
+    spec:
+      initContainers:
+        - name: verify-image
+          image: ghcr.io/sigstore/cosign:v2.2.0
+          command: ["cosign", "verify", "--key=/cosign/cosign.pub", "{{ .Values.gitlab.registry }}/{{ .Values.gitlab.group }}/{{ .Values.gitlab.project }}/todo-client:latest"]
+          volumeMounts:
+            - name: cosign-key
+              mountPath: /cosign
+      containers:
+        - name: todo-client
+          image: {{ .Values.gitlab.registry }}/{{ .Values.gitlab.group }}/{{ .Values.gitlab.project }}/todo-client:latest
+          ports:
+            - containerPort: 80
+          env:
+            - name: REACT_APP_API_URL
+              value: "http://todo-api:8080/api/todos"
+      volumes:
+        - name: cosign-key
+          configMap:
+            name: cosign-public-key
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: todo-client
+spec:
+  selector:
+    app: todo-client
+  ports:
+    - port: 80

--- a/charts/todo-app/values.yaml
+++ b/charts/todo-app/values.yaml
@@ -1,0 +1,4 @@
+gitlab:
+  registry: registry.gitlab.com
+  group: REPLACE_GROUP
+  project: REPLACE_PROJECT

--- a/k8s/argo-app.yaml
+++ b/k8s/argo-app.yaml
@@ -8,7 +8,8 @@ spec:
   source:
     repoURL: https://gitlab.com/REPLACE_GROUP/REPLACE_PROJECT.git
     targetRevision: HEAD
-    path: k8s
+    path: charts/todo-app
+    helm: {}
   destination:
     server: https://kubernetes.default.svc
     namespace: default


### PR DESCRIPTION
## Summary
- add a helm chart for the TODO app
- reference the chart from `argo-app.yaml`
- update deployment docs for helm-based setup
- note Helm use in README

## Testing
- `helm lint charts/todo-app` *(fails: helm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686e1ebfc3308330b34b8ce803f8ba2a