### PR TITLE
Document postgres password secret requirement

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -11,6 +11,19 @@ It assumes you already have container images built and signed in the GitLab regi
 - The Bitnami Sealed Secrets controller installed and the `kubeseal` CLI
   available.
   This is required for `pg-password-sealed.yaml`.
+- A `pg-password` secret for the Postgres database password. Generate a sealed
+  secret with:
+
+  ```bash
+  kubectl create secret generic pg-password \
+    --from-literal POSTGRES_PASSWORD=<your_password> \
+    --namespace todo --dry-run=client -o yaml \
+    | kubeseal --format yaml > charts/todo-app/templates/pg-password-sealed.yaml
+  ```
+
+  Commit the resulting file or otherwise provide it when deploying. If you
+  prefer not to use Sealed Secrets, create a regular Kubernetes `Secret` with
+  the same name and key in the `todo` namespace before running Helm.
 - Copy `.env.example` to `.env` and set `GITLAB_GROUP` and `GITLAB_PROJECT`.
 - These values are consumed by the Helm chart in `charts/todo-app`.
 


### PR DESCRIPTION
## Summary
- document steps for creating a sealed secret containing the postgres password
- mention using a regular Secret as an alternative

## Testing
- `scripts/check-sbom-diff.sh`

------
https://chatgpt.com/codex/tasks/task_e_686e24738c5083308c848320b78a4e09