### PR TITLE
Fix cosign image pull

### DIFF
--- a/charts/todo-app/templates/todo-api-deployment.yaml
+++ b/charts/todo-app/templates/todo-api-deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       initContainers:
         - name: verify-image
-          image: ghcr.io/sigstore/cosign:v2.2.0
+          image: gcr.io/projectsigstore/cosign:v2.2.0
           command: ["cosign", "verify", "--key=/cosign/cosign.pub", "{{ .Values.gitlab.registry }}/{{ .Values.gitlab.group }}/{{ .Values.gitlab.project }}/todo-api:latest"]
           volumeMounts:
             - name: cosign-key

--- a/charts/todo-app/templates/todo-client-deployment.yaml
+++ b/charts/todo-app/templates/todo-client-deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       initContainers:
         - name: verify-image
-          image: ghcr.io/sigstore/cosign:v2.2.0
+          image: gcr.io/projectsigstore/cosign:v2.2.0
           command: ["cosign", "verify", "--key=/cosign/cosign.pub", "{{ .Values.gitlab.registry }}/{{ .Values.gitlab.group }}/{{ .Values.gitlab.project }}/todo-client:latest"]
           volumeMounts:
             - name: cosign-key


### PR DESCRIPTION
## Summary
- update cosign init container to use public gcr image for both deployments

## Testing
- `scripts/check-sbom-diff.sh`

------
https://chatgpt.com/codex/tasks/task_e_686e3128f73c8330a0d61fd6eca27552