### PR TITLE
Add Semgrep SAST job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,7 @@ stages:
   - build
   - sbom
   - scan
+  - sast
   - policy
   - sign
 
@@ -147,10 +148,24 @@ npm-dependency-scan:
   script:
     - cd todo-client
     - npm install --legacy-peer-deps
-    - npm audit --audit-level=high 
+    - npm audit --audit-level=high
   artifacts:
     paths:
       - npm-audit.json
+  dependencies:
+    - build
+  only:
+    - main
+
+semgrep-sast:
+  stage: sast
+  image: returntocorp/semgrep:latest
+  script:
+    - semgrep --config=auto --json -o gl-sast-report.json todo-client todo-api
+  artifacts:
+    paths:
+      - gl-sast-report.json
+  allow_failure: true
   dependencies:
     - build
   only:


### PR DESCRIPTION
## Summary
- add a `sast` stage to the pipeline
- run Semgrep against todo-client and todo-api

## Testing
- `npm test --silent` in `todo-client`
- `./mvnw test -q` in `todo-api` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_686e3318251c8330806dfc561f47a6e9