### PR TITLE
Update cosign public key ConfigMap

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -7,7 +7,7 @@ It assumes you already have container images built and signed in the GitLab regi
 
 - Access to a Kubernetes cluster (`kubectl` configured).
 - Helm installed on your local system.
-- The `cosign.pub` key applied as a ConfigMap so the init containers can verify images.
+- The chart automatically embeds the `cosign.pub` key from the repository's `cosign` directory as the `cosign-public-key` ConfigMap so the init containers can verify images.
 - Export `POSTGRES_PASSWORD` in your shell. Helm will create the `pg-password`
   Kubernetes Secret from this value when deploying.
 - Copy `.env.example` to `.env` and set `GITLAB_GROUP` and `GITLAB_PROJECT`.

--- a/charts/todo-app/cosign.pub
+++ b/charts/todo-app/cosign.pub
@@ -1,0 +1,1 @@
+../../cosign/cosign.pub

--- a/charts/todo-app/templates/cosign-public-key.yaml
+++ b/charts/todo-app/templates/cosign-public-key.yaml
@@ -2,10 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cosign-public-key
-  namespace: default
+  namespace: {{ .Release.Namespace }}
 data:
   cosign.pub: |
-    -----BEGIN PUBLIC KEY-----
-    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE6haOQ3IeA5TQUV+dm8db9TVEkSPp
-    MYWA3E6I7t4bHmLxe+rdeTqL029FdLCFFJtTm1dWuUl9wZl8Itg3GzouzQ==
-    -----END PUBLIC KEY-----
+{{ .Files.Get "cosign.pub" | indent 4 }}


### PR DESCRIPTION
## Summary
- load `cosign.pub` dynamically using a symlinked file in the chart
- namespace for ConfigMap now uses `Release.Namespace`
- update docs about automatic inclusion of `cosign.pub`

## Testing
- `npm test`
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686e32592db483309939eb5c9a8a9848