### PR TITLE
Add unit tests stage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,5 @@
 stages:
+  - test
   - build
   - sbom
   - scan
@@ -8,6 +9,25 @@ stages:
 
 variables:
   REGISTRY: $GITLAB_REGISTRY/$CI_PROJECT_PATH
+
+client-tests:
+  stage: test
+  image: node:18-alpine
+  script:
+    - cd todo-client
+    - npm ci
+    - npm run test
+  only:
+    - main
+
+api-tests:
+  stage: test
+  image: maven:3.9-eclipse-temurin-17
+  script:
+    - cd todo-api
+    - ./mvnw test
+  only:
+    - main
 
 build:
   stage: build


### PR DESCRIPTION
## Summary
- add a new test stage in GitLab CI
- run Jest tests for todo-client
- run Maven tests for todo-api

## Testing
- `npm test --silent -- --watchAll=false`
- `./mvnw test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686e39fd25b4833088ebb4850f2fd7a8