### PR TITLE
Fix ArgoCD GitLab registry access

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -31,7 +31,18 @@ brew install kubectl helm argocd
    ```bash
    kubectl create namespace todo || true
    ```
-2. **Install the chart**
+2. **Create registry credentials**
+   ```bash
+  kubectl create secret docker-registry gitlab-regcred \
+    --namespace todo \
+    --docker-server=registry.gitlab.com \
+    --docker-username=$GITLAB_USERNAME \
+    --docker-password=$GITLAB_TOKEN \
+    --docker-email=you@example.com
+   # The name must match `.Values.gitlab.imagePullSecret` in values.yaml
+   ```
+
+3. **Install the chart**
    ```bash
    helm upgrade --install todo charts/todo-app \
      --namespace todo \

--- a/argo-app.yaml
+++ b/argo-app.yaml
@@ -14,6 +14,7 @@ spec:
         gitlab:
           group: "$GITLAB_GROUP"
           project: "$GITLAB_PROJECT"
+          imagePullSecret: gitlab-regcred
         pgPassword: "$POSTGRES_PASSWORD"
   destination:
     server: https://kubernetes.default.svc

--- a/charts/todo-app/templates/todo-api-deployment.yaml
+++ b/charts/todo-app/templates/todo-api-deployment.yaml
@@ -11,6 +11,8 @@ spec:
       labels:
         app: todo-api
     spec:
+      imagePullSecrets:
+        - name: {{ .Values.gitlab.imagePullSecret }}
       initContainers:
         - name: verify-image
           image: gcr.io/projectsigstore/cosign:v2.2.0

--- a/charts/todo-app/templates/todo-client-deployment.yaml
+++ b/charts/todo-app/templates/todo-client-deployment.yaml
@@ -11,6 +11,8 @@ spec:
       labels:
         app: todo-client
     spec:
+      imagePullSecrets:
+        - name: {{ .Values.gitlab.imagePullSecret }}
       initContainers:
         - name: verify-image
           image: gcr.io/projectsigstore/cosign:v2.2.0

--- a/charts/todo-app/values.yaml
+++ b/charts/todo-app/values.yaml
@@ -2,4 +2,5 @@ gitlab:
   registry: registry.gitlab.com
   group: REPLACE_GROUP
   project: REPLACE_PROJECT
+  imagePullSecret: gitlab-regcred
 pgPassword: ""


### PR DESCRIPTION
## Summary
- add `gitlab.imagePullSecret` value
- inject `imagePullSecrets` into API and client deployments
- include pull secret in Argo CD application values
- document creating the registry secret in deployment guide

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686e4a83006083309d6225402a89846b